### PR TITLE
Расходники изоляции: правка правила сортировки

### DIFF
--- a/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/Немоделируемые.pulldown/Расходники изоляции.pushbutton/script.py
+++ b/ОВиВК.tab/Спецификации.panel/Дополнительные.stack/Немоделируемые.pulldown/Расходники изоляции.pushbutton/script.py
@@ -269,7 +269,7 @@ def script_execute():
 
             for insulationType in insulationsTypeList:
                 if insulationType.typeName == insulationsObject.typeName:
-                    group = "12. Расходники изоляции" + "_" + insulationsObject.typeName
+                    group = "12. Расходники изоляции"
                     if isToGenerate(insulationType.name1, insulationType.expenditure1):
                         number = float(insulationType.expenditure1) * float(insulationsObject.area)
                         if insulationType.isArea1:


### PR DESCRIPTION
Излишне детализировались спецификации у проектировщиков, теперь расходники разных категорий сливаются в одну позицию.